### PR TITLE
Align left the labels in the SLP service popup (bsc#996846)

### DIFF
--- a/package/yast2-slp.changes
+++ b/package/yast2-slp.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Sep  1 12:23:00 UTC 2016 - lslezak@suse.cz
+
+- Align left the labels in the SLP service popup, unify it with the
+  other popup dialogs in YaST (bsc#996846)
+- 3.1.10
+
+-------------------------------------------------------------------
 Mon Jul 25 09:36:32 UTC 2016 - igonzalezsosa@suse.com
 
 - Add a ServiceSelectionDialog to be used by others YaST2 modules

--- a/package/yast2-slp.spec
+++ b/package/yast2-slp.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-slp
-Version:        3.1.9
+Version:        3.1.10
 Release:        0
 
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/lib/slp/dialogs/service_selection.rb
+++ b/src/lib/slp/dialogs/service_selection.rb
@@ -107,9 +107,9 @@ module Yast
         MarginBox(2, 0.5,
           VBox(
             # popup heading (in bold)
-            Heading(heading),
+            Left(Heading(heading)),
             VSpacing(0.5),
-            Label(description),
+            Left(Label(description)),
             VSpacing(0.5),
             RadioButtonGroup(
               Id(:services),


### PR DESCRIPTION
Unify it with the other popup dialogs in YaST.

- 3.1.10

## Before

![yast2-slp-selection-orig](https://cloud.githubusercontent.com/assets/907998/18167535/63f121b2-7051-11e6-9380-166deb5761eb.png)


## After

![yast2-slp-selection](https://cloud.githubusercontent.com/assets/907998/18167479/1ce8d2f6-7051-11e6-97ba-69f52dc3db8c.png)
